### PR TITLE
moved Participating and Meetings & Events pages over from client

### DIFF
--- a/docs/about.rst
+++ b/docs/about.rst
@@ -23,6 +23,7 @@ We provide CIViC data freely to all under the `Creative Commons Public Domain De
    :maxdepth: 1
    :caption: Contents:
 
+   about/participating
    about/faq
    about/domain-experts
    about/partners

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -24,6 +24,7 @@ We provide CIViC data freely to all under the `Creative Commons Public Domain De
    :caption: Contents:
 
    about/participating
+   about/meetings
    about/faq
    about/domain-experts
    about/partners

--- a/docs/about/meetings.rst
+++ b/docs/about/meetings.rst
@@ -1,0 +1,64 @@
+Meetings & Events
+=================
+The CIViC team regularly holds curation jamborees and development hackathons. At curation jamborees, we work with attendees on actual CIViC curation tasks, both educating users and improving the knowledgebase with group curation. During development hackathons, we assist developers integrate their applications and knowledgebases with CIViC via the API, or help developers work on the CIViC codebase by implementing features or fixing bugs.
+
+Upcoming Meetings & Events
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:guilabel:`No upcoming events currently scheduled.`
+
+Past Meetings & Events
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. rubric:: 2018 CIViC Hackathon and Curation Jamboree
+
+----
+
+:Dates: October 15th and October 16th, 2018
+:Location: The Scripps Research Institute
+:Sign Up: `Eventbrite: Cancer Variant Interpretation Hackathon and Curation Jamboree <https://www.eventbrite.com/e/cancer-variant-interpretation-hackathon-and-curation-jamboree-tickets-48287431006?aff=General>`_
+
+.. rubric:: Description
+A hackathon and curation jamboree will be held as a pre-meeting of ASHG, led by the CIViC project team, in collaboration with the ClinGen Somatic working group, and hosted by the Scripps Research Institute. The focus of this meeting will be to continue to develop community consensus on data standards for interpretation of variants in cancer, engage software developers for improved variant interpretation software, engage clinical experts for curation of content and enhance integration and interoperability of resources. Additional related topics will be proposed by meeting participants.
+
+.. rubric:: Meeting Goals
+- Establish community standards and best practices for curation and representation of clinically actionable variants in cancer.
+- Further curation of clinically actionable variants in cancer.
+- Further development of the CIViC web interface for expert crowdsourcing the curation of clinically actionable variants.
+- Promote formation of a collaborative network for community-based development of precision medicine resources.
+- Enhance integration and interoperability of resources through standardization of entities, improvement of APIs, and use of ontologies.
+- Improve drug normalization in variant interpretation knowledgebases.
+- Further develop text-mining strategies for identifying evidence of clinically actionable variants (e.g., CIViCmine).
+- Improved/enhanced integration of MyVariant.info into CIViC.
+- Integrate ClinGen Allele Registry’s variant normalization into MyVariant.info.
+- Standard operating procedures for developing somatic assertions.
+- Development of standard operating procedures for classifying somatic variant oncogenicity.
+- Develop prototype data models for representing compound/complex variants.
+- Examine ways to incentivize the curation community, e.g. Zenodo, bioCADDIE for citable records
+                  
+.. rubric:: 2016 Clinical Interpretation Knowledgebase Hackathon and Curation Jamboree *at the NGS in Molecular Pathology Symposium*
+
+----
+
+:Dates: Tuesday Nov 29 through Friday Dec 2, 2016
+:Location: Netherlands Cancer Institute (NKI), Amsterdam
+:More Info: `NGS in Molecular Pathology Symposium <http://pardot.cartagenia.com/l/104652/2016-08-17/cr37m>`_
+
+.. rubric:: Description
+Precision medicine refers to the use of prevention and treatment strategies that are tailored to the unique features of each individual and their disease. In the context of cancer this might involve the identification of specific mutations shown to predict response to a targeted therapy. The biomedical literature describing these associations is large and growing rapidly. Currently these interpretations exist largely in private or encumbered databases resulting in extensive repetition of effort. Realizing precision medicine requires this information to be centralized, debated and interpreted for application in the clinic. CIViC is an open access, open source, community-driven web resource for Clinical Interpretation of Variants in Cancer. Our goal is to enable precision medicine by providing an educational forum for dissemination of knowledge and active discussion of the clinical significance of cancer genome alterations. This hackathon and jamboree were held to help establish community standards in this space, introduce and engage users with the existing CIViC resource, engage in variant curation activities, and improve the features, user-friendliness and utility of the CIViC curation interface.
+
+.. rubric:: Goals
+
+- Establish community standards and best practices for curation of clinically actionable variants in cancer.
+- Further curation of clinically actionable variants in cancer.
+- Further development of the CIViC web interface for expert crowdsourcing the curation of clinically actionable variants.
+
+.. rubric:: Meeting Format
+
+The 2016 CIViC hackathon and jamboree took the form of an unconference with some presentations but an emphasis on hands-on activities learning to curate variants in the CIViC interface or develop the CIViC code base. Participants formed small expert groups to tackle domain-specific variant curation (jamboree) or new website feature development (hackathon) areas.
+
+.. rubric:: Who Attended
+
+:Hackathon: Software developers, engineers and computational biologists interested in learning and applying back-end and front-end web development skills. Prerequisites: Familiarity with either Ruby/Rails (back-end) or Javascript/Angular (front-end) would be beneficial.
+:Jamboree: Pathologists and oncologists (certified or in training), genome scientists, interested in the problem of sequence variant interpretation for cancer precision medicine. Prerequisites: Basic understanding of the genetic basis of cancer.
+                

--- a/docs/about/participating.rst
+++ b/docs/about/participating.rst
@@ -1,0 +1,41 @@
+Participating
+=============
+
+
+CIViC Principles
+~~~~~~~~~~~~~~~~
+- We believe that the interpretations of clinical actionability required to enable precision medicine should be freely available and openly discussed across a diverse community.
+
+- An interdisciplinary approach is needed to combine the expertise of genome scientists and health care providers, whose efforts are often isolated.
+
+- Content should be created with transparency, kept current, be comprehensive, track provenance, and acknowledge the efforts of creators.
+
+- The interface should be both structured enough to allow computational data mining and agile enough to handle the product of openly-debated, human interpretation.
+
+- CIViC is committed to providing unencumbered and efficient access to community-driven curation and interpretation of cancer mutations. Curated knowledge will remain free and can be accessed anonymously without login unless the user wishes to contribute to content.
+
+- To encourage both academic and commercial engagement CIViC is released with minimal restrictions under a `Creative Commons Public Domain Dedication, CC0 1.0 Universal License <https://creativecommons.org/publicdomain/zero/1.0/>`_. No fees or exclusive access will be introduced. While sharing improvements is strongly encouraged, the data can be adopted and used for nearly any purpose including the creation of commercial applications derived from the knowledge. We require only that attribution be given to the community that created the content.
+
+How to Contribute
+~~~~~~~~~~~~~~~~~
+There are several ways you can make a contribution to this important problem:
+
+
+- **Add:** Propose a new genomic variant (e.g. single nucleotide substitution, structural variant, gene fusion, etc.), add evidence statements that support clinical actions associated with such variants, or help create a synthesized interpretation or summary of the corpus of evidence for a variant.
+
+- **Approve:** Community Editors and Moderators may approve submitted evidence items, after which the community may view and edit the item.
+
+- **View:** Make use of the community-created content in your own research by browsing, searching, and examining detailed evidence items. All CIViC data and source code are provided freely for almost any use.
+
+- **Edit:** Submit a correction or addition to any details about a genomic event, evidence statement, or interpretation.
+
+- **Discuss:** Participate in an ongoing discussion in an effort to reach community consensus on the appropriate clinical action(s) for a genomic event.
+
+- **Apply/Reject:** Editors and Moderators may apply or reject the edits made by other community members, after taking into account community discussions and opinion.
+  
+Before commenting, correcting, or creating, please visit the :doc:`Curating </curating>`, :doc:`Knowledge Model </model>`, and :doc:`FAQ <faq>` pages to learn more about the CIViC data model and `browse the existing content <https://civicdb.org/browse/variants>`_ for examples. Understand the data model but unsure of where to start? Check out our `list of high-priority gene <https://github.com/genome/civic-server/tree/master/public/downloads/RankedCivicGeneCandidates.tsv>`_ for inspiration.
+
+.. figure:: /images/figures/GP-113_CIViC_schema-collaboration_PROCESS_v1a.png
+   :alt: CIViC collaboration process for an Evidence Item
+
+   CIViC collaboration process for an Evidence Item


### PR DESCRIPTION
Couple of remaining pages left from the move.

[Issue #1262](https://github.com/griffithlab/civic-client/issues/1262) will contain redirects to these pages, so this PR should be merged before deploying PRs related to it.